### PR TITLE
Adjust height of logo so it does not spill over

### DIFF
--- a/intergiro/index.css
+++ b/intergiro/index.css
@@ -62,6 +62,7 @@ smoothly-app > header > h1 > a,
 smoothly-app > smoothly-notifier > header > h1 > a {
 	color: transparent;
 	width: 5em;
+	height: 1.6em;
 	margin: 0.75em;
 	background-image: url("./intergiro.svg");
 	background-repeat: no-repeat;


### PR DESCRIPTION
Fix for the following bug: 
Link/logo spills over onto the content, this means that there is a small click area where the link/logo is clicked instead of the content.

![theme-logo-height-fix](https://user-images.githubusercontent.com/14332757/127283349-e33830db-182b-4285-a180-7d3c57bb525e.png)
